### PR TITLE
Refactor PathSampling.run to have separate .run_one_step method

### DIFF
--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -250,22 +250,20 @@ class PathSampling(PathSimulator):
         self.output_stream = original_output_stream
 
     def run(self, n_steps):
-        mcstep = None
         hook_state = None
         self.run_hooks('before_simulation', sim=self)
         for nn in range(n_steps):
-            self.run_one_step()
+            step_info = nn, n_steps
+            hook_state, mcstep = self.run_one_step(step_info, hook_state)
 
         # after simulation hooks
         self.run_hooks('after_simulation', sim=self)
 
-    def run_one_step(self):
+    def run_one_step(self, step_info, hook_state=None):
         # bookkeeping and before_step hooks
         self.step += 1
         logger.info("Beginning MC cycle " + str(self.step))
         step_number = self.step
-        # TODO: anything else we could want in the step info?
-        step_info = (nn, n_steps)
         self.run_hooks('before_step', sim=self, step_number=step_number,
                        step_info=step_info, state=self.sample_set)
 
@@ -303,3 +301,4 @@ class PathSampling(PathSimulator):
                                     results=mcstep,
                                     hook_state=hook_state
                                     )
+        return hook_state, mcstep

--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -254,48 +254,52 @@ class PathSampling(PathSimulator):
         hook_state = None
         self.run_hooks('before_simulation', sim=self)
         for nn in range(n_steps):
-            # bookkeeping and before_step hooks
-            self.step += 1
-            logger.info("Beginning MC cycle " + str(self.step))
-            step_number = self.step
-            # TODO: anything else we could want in the step info?
-            step_info = (nn, n_steps)
-            self.run_hooks('before_step', sim=self, step_number=step_number,
-                           step_info=step_info, state=self.sample_set)
+            self.run_one_step()
 
-            # MCStep, i.e. actual sample move
-            time_start = time.time()  # we time **only** the MCStep (no hooks!)
-            movepath = self._mover.move(self.sample_set, step=self.step)
-            samples = movepath.results
-            new_sampleset = self.sample_set.apply_samples(samples)
-            elapsed_step = time.time() - time_start
-            # TODO: we can save this with the MC steps for timing? The bit
-            # below works, but is only a temporary hack
-            setattr(movepath.details, "timing", elapsed_step)
-
-            mcstep = MCStep(
-                simulation=self,
-                mccycle=self.step,
-                previous=self.sample_set,
-                active=new_sampleset,
-                change=movepath
-            )
-            self._current_step = mcstep
-            #self.save_current_step()  # storage hook does this anyway
-            self.sample_set = new_sampleset
-
-            # run after_step hooks
-            hook_state = self.run_hooks('after_step', sim=self,
-                                        step_number=step_number,
-                                        step_info=step_info,
-                                        # TODO: do we want the new state here
-                                        # i.e. state after step as is right now
-                                        # or do we want something similar to
-                                        # shoot_snapshots where
-                                        # old state == shooting snapshot
-                                        state=self.sample_set,
-                                        results=mcstep,
-                                        hook_state=hook_state
-                                        )
         # after simulation hooks
         self.run_hooks('after_simulation', sim=self)
+
+    def run_one_step(self):
+        # bookkeeping and before_step hooks
+        self.step += 1
+        logger.info("Beginning MC cycle " + str(self.step))
+        step_number = self.step
+        # TODO: anything else we could want in the step info?
+        step_info = (nn, n_steps)
+        self.run_hooks('before_step', sim=self, step_number=step_number,
+                       step_info=step_info, state=self.sample_set)
+
+        # MCStep, i.e. actual sample move
+        time_start = time.time()  # we time **only** the MCStep (no hooks!)
+        movepath = self._mover.move(self.sample_set, step=self.step)
+        samples = movepath.results
+        new_sampleset = self.sample_set.apply_samples(samples)
+        elapsed_step = time.time() - time_start
+        # TODO: we can save this with the MC steps for timing? The bit
+        # below works, but is only a temporary hack
+        setattr(movepath.details, "timing", elapsed_step)
+
+        mcstep = MCStep(
+            simulation=self,
+            mccycle=self.step,
+            previous=self.sample_set,
+            active=new_sampleset,
+            change=movepath
+        )
+        self._current_step = mcstep
+        #self.save_current_step()  # storage hook does this anyway
+        self.sample_set = new_sampleset
+
+        # run after_step hooks
+        hook_state = self.run_hooks('after_step', sim=self,
+                                    step_number=step_number,
+                                    step_info=step_info,
+                                    # TODO: do we want the new state here
+                                    # i.e. state after step as is right now
+                                    # or do we want something similar to
+                                    # shoot_snapshots where
+                                    # old state == shooting snapshot
+                                    state=self.sample_set,
+                                    results=mcstep,
+                                    hook_state=hook_state
+                                    )


### PR DESCRIPTION
This will make it easier to implement other approaches to running path sampling. For example, this should make it possible to:

* clean up run_until_decorrelated
* allow running until a certain number of accepted trajectories
* use algorithms that use a replica reservoir

@hejung : I'm PR'ing this into your branch from openpathsampling#911 to avoid conflicts.

I've gotten some questions about some of the above bullet points, thought I'd make it easier to implement. The case of running until a certain number of trajectories are accepted would mean that `step_info` probably has a different meaning (maybe including number of accepted steps), but that would need to use a different output hook as well!